### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/apsr/_schema.yml
+++ b/_extensions/apsr/_schema.yml
@@ -1,0 +1,21 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+formats:
+  apsr-pdf:
+    runningtitle:
+      type: string
+      description: Short running title used in page headers.
+    runningauthor:
+      type: string
+      description: Running author line used in page headers.
+    word-count:
+      type: string
+      description: Word count value or template token such as {{wordcountref}}.
+    nonblind:
+      type: boolean
+      description: Disable anonymous author mode.
+    classoption:
+      type: array
+      items:
+        type: string
+      description: Additional APSR document class options.

--- a/_extensions/apsr/_snippets.json
+++ b/_extensions/apsr/_snippets.json
@@ -5,9 +5,9 @@
       "format:",
       "  apsr-pdf:",
       "    keep-tex: ${1:false}",
-      "runningtitle: ${2:Short title}",
-      "runningauthor: ${3:Author et al.}",
-      "word-count: \"${4:{{wordcountref}}}\""
+      "    runningtitle: ${2:Short title}",
+      "    runningauthor: ${3:Author et al.}",
+      "    word-count: \"${4:{{wordcountref}}}\""
     ],
     "description": "Insert APSR format settings with running title and word count metadata."
   },

--- a/_extensions/apsr/_snippets.json
+++ b/_extensions/apsr/_snippets.json
@@ -1,6 +1,6 @@
 {
   "apsr-pdf format": {
-    "prefix": "apsr-format",
+    "prefix": "format",
     "body": [
       "format:",
       "  apsr-pdf:",
@@ -12,7 +12,7 @@
     "description": "Insert APSR format settings with running title and word count metadata."
   },
   "APSR floatnote": {
-    "prefix": "apsr-floatnote",
+    "prefix": "floatnote",
     "body": [
       "\\floatnote{${1:This is a note for this float.}}"
     ],

--- a/_extensions/apsr/_snippets.json
+++ b/_extensions/apsr/_snippets.json
@@ -1,0 +1,21 @@
+{
+  "apsr-pdf format": {
+    "prefix": "apsr-format",
+    "body": [
+      "format:",
+      "  apsr-pdf:",
+      "    keep-tex: ${1:false}",
+      "runningtitle: ${2:Short title}",
+      "runningauthor: ${3:Author et al.}",
+      "word-count: \"${4:{{wordcountref}}}\""
+    ],
+    "description": "Insert APSR format settings with running title and word count metadata."
+  },
+  "APSR floatnote": {
+    "prefix": "apsr-floatnote",
+    "body": [
+      "\\floatnote{${1:This is a note for this float.}}"
+    ],
+    "description": "Insert a floatnote for APSR table/figure notes in LaTeX blocks."
+  }
+}


### PR DESCRIPTION
This PR improves Quarto Wizard support (VS Code/Positron) for this extension by adding extension metadata files used for editor assistance.

### What this adds
- `_schema.yml` with extension-specific fields (options/classes/attributes and/or format keys) to enable better completion, hover docs, and validation.
- `_snippets.json` with practical insertion snippets for common extension usage.

### Why
These files improve authoring UX in Quarto projects by making extension configuration and usage easier to discover and less error-prone in VSCode/Positron when using Quarto Wizard.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html